### PR TITLE
Add java assertions to document and verify assumptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,18 @@ dependencies {
     String javaFxVersion = "17.0.7"
     testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: '5.10.0'
     testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: '5.10.0'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-base', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-fxml', version: javaFxVersion, classifier: 'linux'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'win'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'mac'
+    implementation group: 'org.openjfx', name: 'javafx-graphics', version: javaFxVersion, classifier: 'linux'
 }
 
 test {
@@ -40,6 +52,7 @@ application {
 shadowJar {
     archiveBaseName = "yoyo"
     archiveClassifier = null
+    archiveFileName = "yoyo.jar"
 }
 
 run{

--- a/src/main/java/yoyo/command/Command.java
+++ b/src/main/java/yoyo/command/Command.java
@@ -16,7 +16,10 @@ public class Command {
      * @param task The task that is to be executed.
      */
     public String execute(Tasks tasks, Task task) {
+        assert tasks != null : "Tasks container should not be null";
+        assert task != null : "Task to execute should not be null";
         String type = task.getType();
+        assert type != null : "Task type should not be null";
         if (type.equals("mark")) {
             int index = Integer.parseInt(task.getDescription());
             tasks.completeTask(index);

--- a/src/main/java/yoyo/command/Parser.java
+++ b/src/main/java/yoyo/command/Parser.java
@@ -28,6 +28,8 @@ public class Parser {
      * @throws YoyoException If the user input is not in the right format.
      */
     public Task parse(String input, Tasks tasks) throws YoyoException {
+        assert input != null : "Input string to parse cannot be null";
+        assert tasks != null : "Tasks list cannot be null";
         checkInput(input, tasks);
 
         String[] elements = input.split(" /to | /from | /by ");

--- a/src/main/java/yoyo/task/Deadlines.java
+++ b/src/main/java/yoyo/task/Deadlines.java
@@ -15,6 +15,7 @@ public class Deadlines extends Task {
      */
     public Deadlines(String name, String deadline) {
         super(name, "deadline");
+        assert deadline != null : "Deadline string cannot be null";
         this.deadline = LocalDate.parse(deadline);
     }
 

--- a/src/main/java/yoyo/task/Events.java
+++ b/src/main/java/yoyo/task/Events.java
@@ -17,6 +17,8 @@ public class Events extends Task {
      */
     public Events(String name, String start, String end) {
         super(name, "event");
+        assert start != null : "Start date string cannot be null";
+        assert end != null : "End date string cannot be null";
         this.start = LocalDate.parse(start);
         this.end = LocalDate.parse(end);
     }

--- a/src/main/java/yoyo/task/Task.java
+++ b/src/main/java/yoyo/task/Task.java
@@ -31,6 +31,8 @@ public class Task {
      * @param type type of the task
      */
     public Task(String description, String type) {
+        assert description != null : "Task description cannot be null";
+        assert type != null : "Task type cannot be null";
         this.isCompleted = false;
         this.description = description;
         this.type = type;

--- a/src/main/java/yoyo/task/TaskFile.java
+++ b/src/main/java/yoyo/task/TaskFile.java
@@ -51,6 +51,7 @@ public class TaskFile {
      * @return True/False on whether writing is successful.
      */
     public boolean writeList(String message) {
+        assert message != null : "Message to write cannot be null";
         try {
             Files.writeString(path, message);
             return true;

--- a/src/main/java/yoyo/task/Tasks.java
+++ b/src/main/java/yoyo/task/Tasks.java
@@ -50,6 +50,7 @@ public class Tasks {
      * @param index The index of the task to be marked as completed.
      */
     public void completeTask(int index) {
+        assert index > 0 && index <= tasks.size() : "Task index out of bounds for completion";
         tasks.get(index - 1).complete();
     }
 
@@ -58,6 +59,7 @@ public class Tasks {
      * @param index The index of the task to be marked as incomplete.
      */
     public void incompleteTask(int index) {
+        assert index > 0 && index <= tasks.size() : "Task index out of bounds for incompletion";
         tasks.get(index - 1).incomplete();
     }
 
@@ -75,6 +77,7 @@ public class Tasks {
      * @param index The index of the task to be deleted.
      */
     public void deleteTask(int index) {
+        assert index > 0 && index <= tasks.size() : "Task index out of bounds for deletion";
         tasks.remove(index - 1);
     }
 


### PR DESCRIPTION
Add Java `assert` statements across several key classes to document and test important assumptions about input validity and internal state. This improves codebase robustness by catching invalid states during development.

Key changes:
- yoyo.command.Parser: Verify input and tasks list are non-null.
- yoyo.command.Command: Verify tasks and task objects are non-null.
- yoyo.task.Tasks: Add index range checks for task operations.
- yoyo.task.Task: Verify description and type in constructors.
- yoyo.task.TaskFile: Ensure written messages are non-null.
- yoyo.task.Deadlines/Events: Verify date strings before parsing.